### PR TITLE
Update cf to 1.5.2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,11 +4,11 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+compose-flow = "*"
 docker-compose = "*"
 dc-workflows = "*"
 
 [dev-packages]
-compose-flow = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e728e4bc010ac49433eb8ad20c9934718f191c5e0ee2f4fd76151349748cc38f"
+            "sha256": "36bd6afc56ce5de015bd94511fac5c392055008ff15a53aa2b30b5c1b73a0c13"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -44,6 +44,13 @@
             ],
             "version": "==3.0.4"
         },
+        "compose-flow": {
+            "hashes": [
+                "sha256:027c3917ba7d5d568530e318d924ac82df874f1116a48140737468a44bba9065"
+            ],
+            "index": "pypi",
+            "version": "==1.5.2"
+        },
         "dc-workflows": {
             "hashes": [
                 "sha256:8eb38b416e703b17563e0932f56430a87f827f331ac59d9d6139bc35187eed72"
@@ -53,10 +60,10 @@
         },
         "docker": {
             "hashes": [
-                "sha256:dbed56b8ba57b23919794e7cdcf7340c5052e9fd1cbe64b90b4eb9106437e0e3",
-                "sha256:e9cc39e24905e67ba9e2df14c94488f5cf030fb72ae1c60de505ce5ea90503f7"
+                "sha256:52cf5b1c3c394f9abf897638bfc3336d6b63a0f65969d0d4d2da6d3b1d8032b6",
+                "sha256:ad077b49660b711d20f50f344f70cfae014d635ef094bf21b0d7df5f0aeedf99"
             ],
-            "version": "==3.4.0"
+            "version": "==3.4.1"
         },
         "docker-compose": {
             "hashes": [
@@ -166,52 +173,5 @@
             "version": "==0.48.0"
         }
     },
-    "develop": {
-        "boltons": {
-            "hashes": [
-                "sha256:a11e113cf3f0915a21ee2c8c69c315b02f46546ad61d3640e1037b7603f6e16f",
-                "sha256:c7a71928c2b818f2d1263c3c66d3641331350879fb586c8f3ad6f670c72eee2d"
-            ],
-            "version": "==18.0.0"
-        },
-        "compose-flow": {
-            "hashes": [
-                "sha256:e01f009582547c2a4fd1882e79143fa790695f6661e6eea30e822a506533eee3"
-            ],
-            "index": "pypi",
-            "version": "==1.5.0"
-        },
-        "pyyaml": {
-            "hashes": [
-                "sha256:0c507b7f74b3d2dd4d1322ec8a94794927305ab4cebbe89cc47fe5e81541e6e8",
-                "sha256:16b20e970597e051997d90dc2cddc713a2876c47e3d92d59ee198700c5427736",
-                "sha256:3262c96a1ca437e7e4763e2843746588a965426550f3797a79fca9c6199c431f",
-                "sha256:326420cbb492172dec84b0f65c80942de6cedb5233c413dd824483989c000608",
-                "sha256:4474f8ea030b5127225b8894d626bb66c01cda098d47a2b0d3429b6700af9fd8",
-                "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
-                "sha256:5ac82e411044fb129bae5cfbeb3ba626acb2af31a8d17d175004b70862a741a7",
-                "sha256:5f84523c076ad14ff5e6c037fe1c89a7f73a3e04cf0377cb4d017014976433f3",
-                "sha256:827dc04b8fa7d07c44de11fabbc888e627fa8293b695e0f99cb544fdfa1bf0d1",
-                "sha256:b4c423ab23291d3945ac61346feeb9a0dc4184999ede5e7c43e1ffb975130ae6",
-                "sha256:bc6bced57f826ca7cb5125a10b23fd0f2fff3b7c4701d64c439a300ce665fff8",
-                "sha256:c01b880ec30b5a6e6aa67b09a2fe3fb30473008c85cd6a67359a1b15ed6d83a4",
-                "sha256:ca233c64c6e40eaa6c66ef97058cdc80e8d0157a443655baa1b2966e812807ca",
-                "sha256:e863072cdf4c72eebf179342c94e6989c67185842d9997960b3e69290b2fa269"
-            ],
-            "version": "==3.12"
-        },
-        "sh": {
-            "hashes": [
-                "sha256:ae3258c5249493cebe73cb4e18253a41ed69262484bad36fdb3efcb8ad8870bb",
-                "sha256:b52bf5833ed01c7b5c5fb73a7f71b3d98d48e9b9b8764236237bdc7ecae850fc"
-            ],
-            "version": "==1.12.14"
-        },
-        "tag-version": {
-            "hashes": [
-                "sha256:c28c36be9e53f9213bcb582158948674a3eb53add46e71729951782544ea7d58"
-            ],
-            "version": "==0.0.13"
-        }
-    }
+    "develop": {}
 }


### PR DESCRIPTION
This release includes the ability to specify `--config-name` in order to pin
down an environment file stored in `docker config` rather than it being
based on the directory name.

This plays well with Jenkins's way of creating randomly named per-job repo clones.