### PR TITLE
Switch logging driver and increase resource constraints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,10 +60,10 @@ COPY init.groovy /usr/share/jenkins/ref/init.groovy.d/tcp-slave-agent-port.groov
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.121.1}
+ENV JENKINS_VERSION ${JENKINS_VERSION:-2.153}
 
 # jenkins.war checksum, download will be validated using it
-ARG JENKINS_SHA=5bb075b81a3929ceada4e960049e37df5f15a1e3cfc9dc24d749858e70b48919
+ARG JENKINS_SHA=6c9db386bea9a9ecfd5483a0b4f41053b4d77c45669087bba657e48adc1f7302
 
 # Can be used to customize where jenkins.war get downloaded from
 ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war

--- a/compose/docker-compose.deploy.yml
+++ b/compose/docker-compose.deploy.yml
@@ -15,11 +15,11 @@ services:
       replicas: 1
       resources:
         limits:
-          cpus: '1.5'
+          cpus: '2.0'
           memory: 2000M
         reservations:
-          cpus: '1.0'
-          memory: 1500M
+          cpus: '1.5'
+          memory: 2000M
       restart_policy:
         condition: any
         delay: 5s

--- a/compose/docker-compose.deploy.yml
+++ b/compose/docker-compose.deploy.yml
@@ -4,6 +4,8 @@ services:
       - /usr/bin/docker:/usr/bin/docker:ro
       - /usr/lib/x86_64-linux-gnu/libltdl.so.7:/usr/lib/x86_64-linux-gnu/libltdl.so.7:ro
       - /usr/lib/x86_64-linux-gnu/libltdl.so.7.3.1:/usr/lib/x86_64-linux-gnu/libltdl.so.7.3.1:ro
+    logging:
+      driver: json-file
     networks:
       - servicenet
     deploy:

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: ${DOCKER_IMAGE}
     restart: always
     environment:
-      - JAVA_OPTS="-Djava.awt.headless=true"
+      - JAVA_OPTS
     ports:
       - "50000:50000"
       - "8080:8080"


### PR DESCRIPTION
These changes aren't strictly necessary but they will make it easier to debug if anything comes up in future

Also taking this opportunity to upgrade Jenkins itself since we did that as an attempt to get things working and it doesn't seem to have any issues