### PR TITLE
Disable GitHub cache

### DIFF
--- a/compose/compose-flow.yml
+++ b/compose/compose-flow.yml
@@ -25,7 +25,7 @@ rancher:
     - name: jenkins
       namespace: jenkins
       chart: helm-jenkins
-      version: 0.32.9
+      version: 0.36.5
       answers: ./k8s/jenkins-master-answers.yml
   extras:
     staging:

--- a/compose/k8s/jenkins-master-answers.yml
+++ b/compose/k8s/jenkins-master-answers.yml
@@ -3,7 +3,7 @@ rbac.install: true
 Persistence.StorageClass: default-ebs
 Persistence.Size: 20Gi
 
-Master.ImageTag: "2.165"
+Master.ImageTag: "2.170"
 
 {% if '${CF_ENV}' == 'staging' %}
 Master.Affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key: spot

--- a/compose/k8s/jenkins-master-answers.yml
+++ b/compose/k8s/jenkins-master-answers.yml
@@ -23,7 +23,7 @@ Master.resources.requests.memory: 3Gi
 Master.resources.limits.cpu: 2000m
 Master.resources.limits.memory: 4Gi
 
-Master.JavaOpts: -Dhudson.slaves.NodeProvisioner.initialDelay=0 -Dhudson.slaves.NodeProvisioner.MARGIN=50 -Dhudson.slaves.NodeProvisioner.MARGIN0=0.85
+Master.JavaOpts: -Dhudson.slaves.NodeProvisioner.initialDelay=0 -Dhudson.slaves.NodeProvisioner.MARGIN=50 -Dhudson.slaves.NodeProvisioner.MARGIN0=0.85 -Dorg.jenkinsci.plugins.github_branch_source.GitHubSCMSource.cacheSize=0
 
 {% set plugins -%}
 pipeline-stage-tags-metadata:1.3.4.1


### PR DESCRIPTION
We've been experiencing this known issue with GitHub PRs not getting built for no apparent reason: https://issues.jenkins-ci.org/browse/JENKINS-54126

Disabling the cache supposedly resolves this